### PR TITLE
Increase uniquness of the BDBid

### DIFF
--- a/lib/webSqlSync.js
+++ b/lib/webSqlSync.js
@@ -117,7 +117,7 @@ var DBSYNC = {
             } else {
                 self.syncInfo.lastSyncDate = res[0].last_sync;
 				///console.log("Line 115, syncInfo_lastSyncDate sent:", self.syncInfo.lastSyncDate);
-                self.syncInfo.BDBid = res[0].BDBid;	///AB+ Est-ce à la bonne place
+                self.syncInfo.BDBid = res[0].BDBid;	///AB+ Est-ce Ã  la bonne place
                 ///self.syncInfo.username = "";	///AB+
                 ///self.syncInfo.password = "";	///AB+
 				///console.log("Line 117, syncInfo_BDBid sent:", self.syncInfo.BDBid);
@@ -496,7 +496,7 @@ syncNow: function(callBackProgress, callBackUploadProgress, callBackDownloadProg
 					// ex: sqlA = "INSERT INTO " + table.tableName + " (Client.ID, Client.fields, BDBid) VALUES (ServerAnswerRec.ID, ServerAnswerRec.field, ServerAnswerRec.BDBid)"
 					var attList = self._getAttributesList(currRec);
 					console.log("Line 498 curr BDBidValue: ", currBDBidValue);
-					//console.log("Line 481 IDinWebDB : ", IDinWebDB, " curr BDBidValue: ", currBDBidValue);	// -1 et 0	Ça passe ici OK
+					//console.log("Line 481 IDinWebDB : ", IDinWebDB, " curr BDBidValue: ", currBDBidValue);	// -1 et 0	Ã‡a passe ici OK
 					var sqlA = self._buildInsertSQLWithIdNull(tableName,currRec, syncDate);			// it returns an SQL with ?,?,?, ... without values
 					var attValues = self._getMembersValueForIdNull(currRec, attList, syncDate);	// it returns the values to complete the SQL with ?,?,?, ... without values
 					
@@ -509,7 +509,7 @@ syncNow: function(callBackProgress, callBackUploadProgress, callBackDownloadProg
 					console.log("sqlSyncAD1E1F1 line 509 tx: ", tx);
 					//self._executeSql(sqlA, attValues, tx, res_executeSql);	// Bogue avec Chrome et Opera mais pas avec Safari et Next
 					self._executeSql(sqlA, attValues, tx);	// Marche avec tous les browser webSQL
-					//console.log("line 499 insert of _syncEachRec done");	// ça passe ici dans la bonne séquence
+					//console.log("line 499 insert of _syncEachRec done");	// Ã§a passe ici dans la bonne sÃ©quence
 				}
 			} else {	// ID is in webSQL, do an update if the server is more up to date.
      			console.log("Line 515 syncDate : ", syncDate);	
@@ -569,9 +569,26 @@ syncNow: function(callBackProgress, callBackUploadProgress, callBackDownloadProg
 
 		// To have a multi-device, multi-browser app. Required for id-ID mapping of INSERTs done first on a offline device
 		if (this.firstSync == true) {
-	        this._executeSql('UPDATE sync_info SET BDBid = "' + syncDate + '"', [], tx);	// BDBid = unique WebSQL DB identifier (the server last sync date of the first sync) 
-			this.syncInfo.BDBid = syncDate;	//It allows to put BDBid in var DBSYNC at line 45, then it can be put in the clientJSON
+		/*lp20141026: 
+		NOTE: To be fully tested!!
+		Time (=BDBid) is supposed to be in milliseconds but in reality is seconds*1000
+		there is a (small) chance of conflict. Let's reduce this by adding a random number from 1 to 999
+		*/
+		/**
+		 * Returns a random integer between min (inclusive) and max (inclusive)
+		 * Using Math.round() will give you a non-uniform distribution!
+		 */
+		function getRandomInt(min, max) {
+		    return Math.floor(Math.random() * (max - min + 1)) + min;
 		}
+		var syncDatePlusRandom=syncDate+getRandomInt(0,1000);
+		//lp
+		    
+// 	        this._executeSql('UPDATE sync_info SET BDBid = "' + syncDate + '"', [], tx);	// BDBid = unique WebSQL DB identifier (the server last sync date of the first sync) 
+// 		this.syncInfo.BDBid = syncDate;	//It allows to put BDBid in var DBSYNC at line 45, then it can be put in the clientJSON
+		this._executeSql('UPDATE sync_info SET BDBid = "' + syncDatePlusRandom + '"', [], tx);	// BDBid = unique WebSQL DB identifier (the server last sync date of the first sync) //lp20141026
+		this.syncInfo.BDBid = syncDatePlusRandom;	//It allows to put BDBid in var DBSYNC at line 45, then it can be put in the clientJSON //lp20141026
+		} 
 
         this.firstSync = false;
         this.syncInfo.lastSyncDate = syncDate;


### PR DESCRIPTION
BDBid is the index which uniquely identify each client (even different browsers on same device).
It's based on the second the first sync is made multiplied by 1000.
There is a (slight) chance of conflict. To increase the uniqueness we add at creation a random number.
NOTE: looks ok but still need FULL test!